### PR TITLE
Fix legend undefined check

### DIFF
--- a/source/assets/js/geomedia.js
+++ b/source/assets/js/geomedia.js
@@ -176,7 +176,7 @@ function getElementLegend(elementID, layerName) {
 
               // Legend for raster data
               var legendData = legendJSON.Raster.colormap.entries;
-              if (legendData !== 'undefined') {
+              if (legendData !== undefined) {
                 var divLegend = $("<div/>").attr("id","indexLegend");
                 $("#"+elementID).append(divLegend);
                 arrayColors = [];
@@ -204,7 +204,7 @@ function getElementLegend(elementID, layerName) {
               // Legend for linestring data
               var legendData = legendJSON.Line;
               console.log(legendData);
-              if (legendData !== 'undefined') {
+              if (legendData !== undefined) {
                 var divLegend = $("<div/>").attr("id","indexLegend");
                 $("#"+elementID).append(divLegend);
 
@@ -221,7 +221,7 @@ function getElementLegend(elementID, layerName) {
               // Legend for polygon data
               var legendData = legendJSON.Polygon;
               console.log(legendData);
-              if (legendData !== 'undefined') {
+              if (legendData !== undefined) {
                 var divLegend = $("<div/>").attr("id","indexLegend");
                 $("#"+elementID).append(divLegend);
 
@@ -240,7 +240,7 @@ function getElementLegend(elementID, layerName) {
               // Legend for point data
               var legendData = legendJSON.Point.graphics[0];
               console.log(legendData);
-              if (legendData !== 'undefined') {
+              if (legendData !== undefined) {
                 var divLegend = $("<div/>").attr("id","indexLegend");
                 $("#"+elementID).append(divLegend);
 


### PR DESCRIPTION
## Summary
- fix legend data undefined comparison in geomedia.js

## Testing
- `node --check source/assets/js/geomedia.js && echo 'syntax ok'`
- manual Node test for legendData undefined detection

------
https://chatgpt.com/codex/tasks/task_e_68946a6ca62883229af092d1a2324204